### PR TITLE
Fix initial render of keyboard

### DIFF
--- a/src/lib/components/Keyboard.js
+++ b/src/lib/components/Keyboard.js
@@ -79,7 +79,7 @@ class App extends Component {
   }
 
   componentDidMount(){
-    this.initKeyboard();
+    this.initKeyboard(this.props);
   }
 
   initKeyboard = (props) => {

--- a/src/lib/components/Keyboard.js
+++ b/src/lib/components/Keyboard.js
@@ -8,6 +8,14 @@ class App extends Component {
     input: '',
   }
 
+  componentDidMount(){
+    this.initKeyboard(this.props);
+  }
+
+  componentWillReceiveProps = nextProps => {
+    this.keyboard.setOptions(nextProps);
+  }
+
   clearInput = (inputName) => {
     inputName = inputName || "default";
 
@@ -72,14 +80,6 @@ class App extends Component {
       if(typeof this.props.onChangeAll === "function")
         this.props.onChangeAll(this.keyboard.input);
     });
-  }
-
-  componentWillReceiveProps = nextProps => {
-    this.keyboard.setOptions(nextProps);
-  }
-
-  componentDidMount(){
-    this.initKeyboard(this.props);
   }
 
   initKeyboard = (props) => {

--- a/src/lib/components/Keyboard.js
+++ b/src/lib/components/Keyboard.js
@@ -5,19 +5,7 @@ import 'simple-keyboard/build/css/index.css';
 
 class App extends Component {
   state = {
-    input: ''
-  }
-
-  componentWillReceiveProps = (nextProps) => {
-    if(
-      this.props !== nextProps
-    ){
-      this.setState({
-        layoutName: nextProps.layoutName,
-        layout: nextProps.layout,
-        themeClass: nextProps.theme
-      });
-    }
+    input: '',
   }
 
   clearInput = (inputName) => {
@@ -56,7 +44,7 @@ class App extends Component {
      */
     if(typeof this.props.onKeyPress === "function")
       this.props.onKeyPress(button);
-    
+
     if(debug){
       console.log("Key pressed:", button);
     }
@@ -71,7 +59,7 @@ class App extends Component {
       if(debug){
         console.log('Input changed:', this.state.input);
       }
-      
+
       /**
        * Calling user onChange
        */


### PR DESCRIPTION
If a layout was passed through props, it would not show until the user pressed one of the keys (until first `componentWillReceiveProps` call). The `initKeyboard` method needed to be passed props in componentDidMount to fix this.

I also fixed some other issues
* `componentWillReceiveProps` was defined twice. The first implementation only set some unused state, so I deleted this.
* I moved componentWillReceiveProps and componentDidMount to the top of the file, as it is very common that lifecycle methods are in the beginning of the class definition.

Other notes:
* The Keyboard component class is named "App". It should be named "Keyboard" or something that makes more sense in stacktraces/debugging.
 