### PR TITLE
chore(package): move simple-keyboard as dev dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6170,12 +6170,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6190,17 +6192,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6317,7 +6322,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6329,6 +6335,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6343,6 +6350,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6350,12 +6358,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6374,6 +6384,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6454,7 +6465,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6466,6 +6478,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6587,6 +6600,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6913,9 +6927,9 @@
       "dev": true
     },
     "har-validator": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.2.tgz",
-      "integrity": "sha512-OFxb5MZXCUMx43X7O8LK4FKggEQx6yC5QPmOcBnYbJ9UjxEcMcrMbaR0af5HZpqeFopw2GwQRQi34ZXI7YLM5w==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
       "dev": true,
       "requires": {
         "ajv": "^6.5.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-simple-keyboard",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14300,7 +14300,8 @@
     "simple-keyboard": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/simple-keyboard/-/simple-keyboard-2.8.0.tgz",
-      "integrity": "sha512-nCLFvI4ZExjtDEbvSYxwzm/e23GAk6+ICdgoqQ8CU7dmJBU+z5dHN7tHjGPLeqFQ9hGqY95+ehRIW7jd/qyOUQ=="
+      "integrity": "sha512-nCLFvI4ZExjtDEbvSYxwzm/e23GAk6+ICdgoqQ8CU7dmJBU+z5dHN7tHjGPLeqFQ9hGqY95+ehRIW7jd/qyOUQ==",
+      "dev": true
     },
     "simple-swizzle": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -35,9 +35,7 @@
     "osk"
   ],
   "license": "MIT",
-  "dependencies": {
-    "simple-keyboard": "^2.8.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@babel/core": "7.1.0",
     "@svgr/webpack": "2.4.1",
@@ -83,6 +81,7 @@
     "react-dom": "^16.6.1",
     "resolve": "1.8.1",
     "sass-loader": "7.1.0",
+    "simple-keyboard": "^2.8.0",
     "style-loader": "0.23.0",
     "terser-webpack-plugin": "1.1.0",
     "url-loader": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "file-loader": "2.0.0",
     "fork-ts-checker-webpack-plugin-alt": "0.4.14",
     "fs-extra": "7.0.0",
+    "har-validator": "^5.1.3",
     "html-webpack-plugin": "4.0.0-alpha.2",
     "identity-obj-proxy": "3.0.0",
     "jest": "23.6.0",


### PR DESCRIPTION
Move simple-keyboard dependency from `dependencies` to `devDependencies` as its not used in production but only in dev mode. In production mode, the package is bundled in the `react-simple-keyboard` built file, so set `simple-keyboard` as dependency will indicate to npm to install it in the `node_module` of the project, while we don't need it as it's packaged in the `react-simple-keyboard` built file.
In production mode, the package is bundled in the `react-simple-keyboard` built file, so `simple-keyboard` as dependency will indicate to npm to install it in the `node_module` of the project, while we don't need it as it's packaged in the `react-simple-keyboard` built file.