### PR TITLE
fix(typings): makes keyboardRef not required, as it is specified in docs

### DIFF
--- a/src/lib/@types/index.d.ts
+++ b/src/lib/@types/index.d.ts
@@ -147,7 +147,7 @@ declare module 'react-simple-keyboard' {
     /**
      * keyboardRef
      */
-    keyboardRef: (r: any) => void;
+    keyboardRef?: (r: any) => void;
 
     /**
      * Executes the callback function on key press. Returns button layout name (i.e.: "{shift}").


### PR DESCRIPTION
## Description

#368 adds keyboardRef to the TypescriptTypings of the Keyboard component. But this prop is not required according to the docs, so this PR marks this prop as optional.

## Checks

- [x] Tests ( `npm run test -- --coverage` ) Coverage at `./coverage/lcov-report/index.html` should be 100%