### PR TITLE
textarea resize removed

### DIFF
--- a/src/demo/css/App.css
+++ b/src/demo/css/App.css
@@ -25,6 +25,17 @@
   width: 100%;
   height: 100%;
   font-size: 18px;
+  resize: none;
+}
+
+.demoPage .inputContainer::-webkit-scrollbar {
+  width: 0.4vw;
+  background-color: rgba(0, 0, 0, 0);
+}
+
+.demoPage .inputContainer::-webkit-scrollbar-thumb {
+  max-height: 1vh;
+  background-color: rgba(0, 0, 0, 0.4);
 }
 
 .simple-keyboard.hg-layout-custom {


### PR DESCRIPTION
When I ran the demo, I could see the resize button at the bottom right (as is the case with the `<textarea>` element). Feeling that this allows the user to manipulate the "keyboard input area" size (which makes it look kinda bad with the whole scrollbar thing appearing), I decided to remove the resizing option. Also, I tried making some "fixes" to the scrollbar. Basically, not making it look out of place. 