### PR TITLE
Fix "Missing keyboard destroy on unmount" #2522 bug

### DIFF
--- a/src/lib/components/Keyboard.tsx
+++ b/src/lib/components/Keyboard.tsx
@@ -12,6 +12,20 @@ const KeyboardReact = (props: KeyboardReactInterface["options"]) => {
   const previousProps = React.useRef(props);
 
   React.useEffect(() => {
+    /**
+     * Whenever this component is unmounted, ensure that Keyboard object that
+     * it created is destroyed so that it removes any event handlers that it
+     * may have installed.
+     */
+    return () => {
+      if (keyboardRef.current) {
+        keyboardRef.current.destroy();
+      }
+      initRef.current = false;
+    };
+  }, []);
+
+  React.useEffect(() => {
     const parsedProps = parseProps(props) as any;
 
     /**

--- a/src/lib/components/KeyboardModern.tsx
+++ b/src/lib/components/KeyboardModern.tsx
@@ -13,6 +13,20 @@ const KeyboardReact = (props: KeyboardReactInterface["options"]) => {
   const previousProps = React.useRef(props);
 
   React.useEffect(() => {
+    /**
+     * Whenever this component is unmounted, ensure that Keyboard object that
+     * it created is destroyed so that it removes any event handlers that it
+     * may have installed.
+     */
+    return () => {
+      if (keyboardRef.current) {
+        keyboardRef.current.destroy();
+      }
+      initRef.current = false;
+    };
+  }, []);
+
+  React.useEffect(() => {
     const parsedProps = parseProps(props) as any;
 
     /**


### PR DESCRIPTION


## Description

Added an additional useEffect with an empty dependency array to the 'Keyboard' and 'KeyboardModern' components. 

This useEffect's return function is called whenever the react component is unmounted and is used here to ensure that destroy() is called on Keyboard object, thus cleaning up any event handlers the Keyboard object may have installed. This return function also changes the initRef.current value back to false in case the component is somehow remounted, which apparently may happen under certain React versions when running with StrictMode enabled.

